### PR TITLE
Joda-time is required dependency for AWS Lambda

### DIFF
--- a/lambda-lite-dependencies/pom.xml
+++ b/lambda-lite-dependencies/pom.xml
@@ -112,10 +112,6 @@
                         <groupId>com.amazonaws</groupId>
                         <artifactId>aws-java-sdk-dynamodb</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>joda-time</groupId>
-                        <artifactId>joda-time</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
As described in https://github.com/aws/aws-lambda-java-libs/issues/72, we still need Joda Time.