### PR TITLE
Allow setting "Content-Type" for a specific response

### DIFF
--- a/lambda-lite-core/src/main/java/io/github/stepio/lambda/enums/MediaType.java
+++ b/lambda-lite-core/src/main/java/io/github/stepio/lambda/enums/MediaType.java
@@ -1,0 +1,37 @@
+package io.github.stepio.lambda.enums;
+
+/**
+ * Represents common values of Media Type (MIME Type), similar to {@code org.springframework.http.MediaType}.
+ */
+public enum MediaType {
+
+    ALL("*/*"),
+    APPLICATION_ATOM_XML("application/atom+xml"),
+    APPLICATION_FORM_URLENCODED("application/x-www-form-urlencoded"),
+    APPLICATION_JSON("application/json"),
+    APPLICATION_JSON_UTF8("application/json;charset=UTF-8"),
+    APPLICATION_OCTET_STREAM("application/octet-stream"),
+    APPLICATION_PDF("application/pdf"),
+    APPLICATION_RSS_XML("application/rss+xml"),
+    APPLICATION_XHTML_XML("application/xhtml+xml"),
+    APPLICATION_XML("application/xml"),
+    IMAGE_GIF("image/gif"),
+    IMAGE_JPEG("image/jpeg"),
+    IMAGE_PNG("image/png"),
+    MULTIPART_FORM_DATA("multipart/form-data"),
+    TEXT_EVENT_STREAM("text/event-stream"),
+    TEXT_HTML("text/html"),
+    TEXT_MARKDOWN("text/markdown"),
+    TEXT_PLAIN("text/plain"),
+    TEXT_XML("text/xml");
+
+    private final String value;
+
+    MediaType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/lambda-lite-core/src/main/java/io/github/stepio/lambda/util/Responses.java
+++ b/lambda-lite-core/src/main/java/io/github/stepio/lambda/util/Responses.java
@@ -1,19 +1,39 @@
 package io.github.stepio.lambda.util;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.github.stepio.lambda.enums.MediaType;
 import io.github.stepio.lambda.enums.Status;
 
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 
 public class Responses {
 
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+
     private Responses() {
     }
 
+    public static Map<String, String> contentTypeHeader(String mediaType) {
+        return singletonMap(HEADER_CONTENT_TYPE, mediaType);
+    }
+
     public static APIGatewayProxyResponseEvent ok(String body) {
-        return response(Status.OK.getStatusCode(), null, body);
+        return ok(MediaType.APPLICATION_JSON, body); // "application/json" is implicit default value for AWS Lambda
+    }
+
+    public static APIGatewayProxyResponseEvent ok(MediaType mediaType, String body) {
+        return ok(mediaType.getValue(), body);
+    }
+
+    public static APIGatewayProxyResponseEvent ok(String mediaType, String body) {
+        return ok(contentTypeHeader(mediaType), body);
+    }
+
+    public static APIGatewayProxyResponseEvent ok(Map<String, String> headers, String body) {
+        return response(Status.OK.getStatusCode(), headers, body);
     }
 
     public static APIGatewayProxyResponseEvent noContent() {

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/LambdaHandlerTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/LambdaHandlerTest.java
@@ -57,7 +57,7 @@ public class LambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_badRequest() {
+    public void handleRequestWithBadRequest() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("GET");
         response = handler.handleRequest(request, this.context);
@@ -66,7 +66,7 @@ public class LambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_internalServerError() {
+    public void handleRequestWithInternalServerError() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("GET")
                 .withMultiValueQueryStringParameters(singletonMap("dummyParam", singletonList("13")));
@@ -83,7 +83,7 @@ public class LambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_methodNotAllowed() {
+    public void handleRequestWithMethodNotAllowed() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("PUT");
         response = this.handler.handleRequest(request, this.context);
@@ -107,7 +107,7 @@ public class LambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_noContent() {
+    public void handleRequestWithNoContent() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("DELETE");
         response = this.handler.handleRequest(request, this.context);
@@ -120,7 +120,7 @@ public class LambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_ok() {
+    public void handleRequestWithOk() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("GET")
                 .withQueryStringParameters(singletonMap("dummyParam", "dummyValue"));

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/RequestContextTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/RequestContextTest.java
@@ -22,12 +22,12 @@ public class RequestContextTest {
     }
 
     @Test
-    public void getRequest_withDummy() {
+    public void getRequestWithDummy() {
         assertThat(this.requestContext.getRequest()).isSameAs(this.request);
     }
 
     @Test
-    public void getContext_withDummy() {
+    public void getContextWithDummy() {
         assertThat(this.requestContext.getContext()).isSameAs(this.context);
     }
 }

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MediaTypeTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MediaTypeTest.java
@@ -1,0 +1,16 @@
+package io.github.stepio.lambda.enums;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MediaTypeTest {
+
+    @Test
+    public void getValue_someValues() {
+        assertThat(MediaType.ALL.getValue()).isEqualTo("*/*");
+        assertThat(MediaType.APPLICATION_JSON.getValue()).isEqualTo("application/json");
+        assertThat(MediaType.TEXT_HTML.getValue()).isEqualTo("text/html");
+        assertThat(MediaType.TEXT_PLAIN.getValue()).isEqualTo("text/plain");
+    }
+}

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MediaTypeTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MediaTypeTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MediaTypeTest {
 
     @Test
-    public void getValue_someValues() {
+    public void getValueExpectStandardMediaType() {
         assertThat(MediaType.ALL.getValue()).isEqualTo("*/*");
         assertThat(MediaType.APPLICATION_JSON.getValue()).isEqualTo("application/json");
         assertThat(MediaType.TEXT_HTML.getValue()).isEqualTo("text/html");

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MethodTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/MethodTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MethodTest {
 
     @Test
-    public void of_values() {
+    public void ofWithAllValues() {
         Optional<Method> optional = Method.of("dummy");
         assertThat(optional.isPresent()).isFalse();
 

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/StatusTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/enums/StatusTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StatusTest {
 
     @Test
-    public void of_values() {
+    public void ofWithAllValues() {
         Optional<Status> optional = Status.of(42);
         assertThat(optional.isPresent()).isFalse();
 

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/AssertTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/AssertTest.java
@@ -13,7 +13,7 @@ import static io.github.stepio.lambda.util.Assert.notNull;
 public class AssertTest {
 
     @Test
-    public void notNull_withDummy() {
+    public void notNullWithDummyValues() {
         notNull(Integer.valueOf(42), "Test comment");
         assertThatThrownBy(() -> notNull(null, "Instance <%s> is empty", null))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -24,7 +24,7 @@ public class AssertTest {
     }
 
     @Test
-    public void hasLength_withDummy() {
+    public void hasLengthWithDummyValues() {
         hasLength("42", "Test comment");
         assertThatThrownBy(() -> hasLength("", "Instance <%s> is empty", ""))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -32,7 +32,7 @@ public class AssertTest {
     }
 
     @Test
-    public void message_noParams() {
+    public void messageWithNoParams() {
         assertThat(message(null)).isEqualTo(null);
         assertThat(message("")).isEqualTo("");
         assertThat(message("Qwerty123")).isEqualTo("Qwerty123");
@@ -42,7 +42,7 @@ public class AssertTest {
     }
 
     @Test
-    public void message_withParams() {
+    public void messageWithParams() {
         assertThat(message("Qwerty123", "value")).isEqualTo("Qwerty123");
         assertThat(message("Text %s", "value")).isEqualTo("Text value");
         assertThat(message("Text %s %s", "value1", "value2")).isEqualTo("Text value1 value2");

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/QueryTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/QueryTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class QueryTest {
 
     @Test
-    public void list_withDummy() {
+    public void listWithDummyValues() {
         assertThatThrownBy(() -> Query.query(null, "dummy"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Request cannot be null");
@@ -31,7 +31,7 @@ public class QueryTest {
     }
 
     @Test
-    public void optional_withDummy() {
+    public void optionalWithDummyValues() {
         assertThatThrownBy(() -> Query.query(null, "dummy"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Request cannot be null");
@@ -44,7 +44,7 @@ public class QueryTest {
     }
 
     @Test
-    public void required_withDummy() {
+    public void requiredWithDummyValues() {
         assertThatThrownBy(() -> Query.query(null, "dummy"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Request cannot be null");
@@ -56,7 +56,7 @@ public class QueryTest {
     }
 
     @Test
-    public void query_withDummy() {
+    public void queryWithDummyValues() {
         assertThatThrownBy(() -> Query.query(null, "dummy"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Request cannot be null");
@@ -67,7 +67,7 @@ public class QueryTest {
     }
 
     @Test
-    public void validate_withDummy() {
+    public void validateWithDummyValues() {
         Query.validate(new APIGatewayProxyRequestEvent());
         assertThatThrownBy(() -> Query.validate(null))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/ResponsesTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/ResponsesTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.entry;
 public class ResponsesTest {
 
     @Test
-    public void ok_checkStatus() {
+    public void okCheckStatusBodyContentType() {
         APIGatewayProxyResponseEvent responseEvent = Responses.ok(MediaType.TEXT_PLAIN, "dummy7");
         assertThat(responseEvent.getStatusCode()).isEqualTo(200);
         assertThat(responseEvent.getBody()).isEqualTo("dummy7");
@@ -22,51 +22,51 @@ public class ResponsesTest {
     }
 
     @Test
-    public void noContent_checkStatus() {
+    public void noContentCheckStatusNoBody() {
         assertThat(Responses.noContent().getStatusCode()).isEqualTo(204);
         assertThat(Responses.noContent().getBody()).isNull();
     }
 
     @Test
-    public void badRequest_checkStatus() {
+    public void badRequestCheckStatusNoBody() {
         assertThat(Responses.badRequest().getStatusCode()).isEqualTo(400);
         assertThat(Responses.badRequest().getBody()).isNull();
     }
 
     @Test
-    public void notFound_checkStatus() {
+    public void notFoundCheckStatusNoBody() {
         assertThat(Responses.notFound().getStatusCode()).isEqualTo(404);
         assertThat(Responses.notFound().getBody()).isNull();
     }
 
     @Test
-    public void methodNotAllowed_checkStatus() {
+    public void methodNotAllowedCheckStatusNoBody() {
         assertThat(Responses.methodNotAllowed().getStatusCode()).isEqualTo(405);
         assertThat(Responses.methodNotAllowed().getBody()).isNull();
     }
 
     @Test
-    public void internalServerError_checkStatus() {
+    public void internalServerErrorCheckStatusNoBody() {
         assertThat(Responses.internalServerError().getStatusCode()).isEqualTo(500);
         assertThat(Responses.internalServerError().getBody()).isNull();
     }
 
     @Test
-    public void status_withStatus() {
+    public void statusWithStatus() {
         APIGatewayProxyResponseEvent response = Responses.status(Status.CREATED);
         assertThat(response.getStatusCode()).isEqualTo(201);
         assertThat(response.getBody()).isNull();
     }
 
     @Test
-    public void status_withStatusCode() {
+    public void statusWithStatusCode() {
         APIGatewayProxyResponseEvent response = Responses.status(201);
         assertThat(response.getStatusCode()).isEqualTo(201);
         assertThat(response.getBody()).isNull();
     }
 
     @Test
-    public void response_custom() {
+    public void responseWithHeaders() {
         Map<String, String> headers = new HashMap<>();
         headers.put("Content-Type", "text/html;charset=UTF-8");
         headers.put("Content-Encoding", "gzip");

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/ResponsesTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/ResponsesTest.java
@@ -1,6 +1,7 @@
 package io.github.stepio.lambda.util;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.github.stepio.lambda.enums.MediaType;
 import io.github.stepio.lambda.enums.Status;
 import org.junit.Test;
 
@@ -14,8 +15,10 @@ public class ResponsesTest {
 
     @Test
     public void ok_checkStatus() {
-        assertThat(Responses.ok("dummy").getStatusCode()).isEqualTo(200);
-        assertThat(Responses.ok("dummy7").getBody()).isEqualTo("dummy7");
+        APIGatewayProxyResponseEvent responseEvent = Responses.ok(MediaType.TEXT_PLAIN, "dummy7");
+        assertThat(responseEvent.getStatusCode()).isEqualTo(200);
+        assertThat(responseEvent.getBody()).isEqualTo("dummy7");
+        assertThat(responseEvent.getHeaders()).contains(entry("Content-Type", "text/plain"));
     }
 
     @Test

--- a/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/StringUtilsTest.java
+++ b/lambda-lite-core/src/test/java/io/github/stepio/lambda/util/StringUtilsTest.java
@@ -9,26 +9,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StringUtilsTest {
 
     @Test
-    public void hasLength_isEmpty() {
+    public void hasLengthWithEmpty() {
         assertThat(hasLength(null)).isFalse();
         assertThat(hasLength("")).isFalse();
     }
 
     @Test
-    public void hasLength_isNotEmpty() {
+    public void hasLengthWithNotEmpty() {
         assertThat(hasLength(" ")).isTrue();
         assertThat(hasLength("qwerty")).isTrue();
         assertThat(hasLength("123")).isTrue();
     }
 
     @Test
-    public void isEmpty_isEmpty() {
+    public void isEmptyWithEmpty() {
         assertThat(isEmpty(null)).isTrue();
         assertThat(isEmpty("")).isTrue();
     }
 
     @Test
-    public void isEmpty_isNotEmpty() {
+    public void isEmptyWithNotEmpty() {
         assertThat(isEmpty(" ")).isFalse();
         assertThat(isEmpty("qwerty")).isFalse();
         assertThat(isEmpty("123")).isFalse();

--- a/lambda-lite-json/src/test/java/io/github/stepio/lambda/json/BodyRequestContextTest.java
+++ b/lambda-lite-json/src/test/java/io/github/stepio/lambda/json/BodyRequestContextTest.java
@@ -25,17 +25,17 @@ public class BodyRequestContextTest {
     }
 
     @Test
-    public void getBody_withDummy() {
+    public void getBodyWithDummy() {
         assertThat(this.requestContext.getBody()).isSameAs(this.body);
     }
 
     @Test
-    public void getRequest_withDummy() {
+    public void getRequestWithDummy() {
         assertThat(this.requestContext.getRequest()).isSameAs(this.request);
     }
 
     @Test
-    public void getContext_withDummy() {
+    public void getContextWithDummy() {
         assertThat(this.requestContext.getContext()).isSameAs(this.context);
     }
 }

--- a/lambda-lite-json/src/test/java/io/github/stepio/lambda/json/DefaultLambdaHandlerTest.java
+++ b/lambda-lite-json/src/test/java/io/github/stepio/lambda/json/DefaultLambdaHandlerTest.java
@@ -41,7 +41,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void constructor_generics() {
+    public void constructorWithGenerics() {
         StringLambdaHandlerExplicit stringHandlerExplicit = new StringLambdaHandlerExplicit();
         assertThat(this.stringHandler.bodyClass).isSameAs(stringHandlerExplicit.bodyClass);
         assertThat(this.stringHandler.responseClass).isSameAs(stringHandlerExplicit.responseClass);
@@ -49,7 +49,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void reader_caches() {
+    public void readerWithCaches() {
         ObjectReader reader1 = this.defaultHandler.reader(ABody.class);
         ABody body = dummy();
         ObjectReader reader2 = this.defaultHandler.reader(body.getClass());
@@ -57,7 +57,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void writer_caches() {
+    public void writerWithCaches() {
         ObjectWriter writer1 = this.defaultHandler.writer(ABody.class);
         ABody body = dummy();
         ObjectWriter writer2 = this.defaultHandler.writer(body.getClass());
@@ -65,7 +65,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void writeDummy_thenRead() throws IOException {
+    public void writeDummyThenRead() throws IOException {
         ABody body = dummy();
         String text = this.defaultHandler.writer(body.getClass())
                 .writeValueAsString(body);
@@ -75,7 +75,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void writeEmpty_thenRead() throws IOException {
+    public void writeEmptyThenRead() throws IOException {
         ABody empty = new ABody();
         ObjectReader reader = this.defaultHandler.reader(ABody.class);
         ABody other = reader.readValue("{}");
@@ -83,7 +83,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_GET() {
+    public void handleRequestWithGET() {
 
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("GET")
@@ -97,7 +97,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_POST() {
+    public void handleRequestWithPOST() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("POST")
                 .withBody("{\"name\":\"fail\"}");
@@ -116,7 +116,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_PUT() {
+    public void handleRequestWithPUT() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("PUT")
                 .withBody("{\"name\":\"fail\"}");
@@ -135,7 +135,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void handleRequest_DELETE() {
+    public void handleRequestWithDELETE() {
         request = new APIGatewayProxyRequestEvent()
                 .withHttpMethod("DELETE")
                 .withBody("{\"name\":\"fail\"}");
@@ -154,20 +154,20 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void body_empty() {
+    public void bodyWithEmpty() {
         request = new APIGatewayProxyRequestEvent();
         assertThat(this.stringHandler.body(request)).isNull();
     }
 
     @Test
-    public void body_text() {
+    public void bodyWithText() {
         request = new APIGatewayProxyRequestEvent()
                 .withBody("Request, world!");
         assertThat(this.stringHandler.body(request)).isEqualTo("Request, world!");
     }
 
     @Test
-    public void body_entity() {
+    public void bodyWithEntity() {
         assertThatThrownBy(() -> this.testHandler.body(
                 new APIGatewayProxyRequestEvent().withBody("{name:dummy}")
         )).isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("Failed to extract class");
@@ -182,7 +182,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void wrap_empty() {
+    public void wrapWithEmpty() {
         response = this.stringHandler.wrap(null);
         assertThat(response)
                 .hasFieldOrPropertyWithValue("statusCode", 204);
@@ -192,7 +192,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void wrap_text() {
+    public void wrapWithText() {
         response = this.stringHandler.wrap("Response, world!");
         assertThat(response)
                 .hasFieldOrPropertyWithValue("statusCode", 200)
@@ -200,7 +200,7 @@ public class DefaultLambdaHandlerTest {
     }
 
     @Test
-    public void wrap_entity() {
+    public void wrapWithEntity() {
         AResult result = new AResult();
         result.setValue("Joy42");
         response = this.testHandler.wrap(result);


### PR DESCRIPTION
While testing sample app I got next error in response:
```
Unexpected 'H'
```

Sample app tried sending dummy text `Hello, world!`, as implemented here:
https://github.com/stepio/lambda-lite-samples/blob/master/lambda-lite-hello-world/src/main/java/io/github/stepio/lambda/sample/HelloWorldLambdaHandler.java

As I checked, `content-type` in response was `application/json`, so the problem is that text "Hello, world!" cannot be parsed as JSON, which is quite obvious.

Also found a hint here:
https://stackoverflow.com/questions/46171369/how-to-change-aws-lambda-content-type-from-plain-text-to-html
It's stated that `application/json` is implicit default value, so most probably we just need to set `content-type` explicitly.